### PR TITLE
Reverting mdms v2 changes in bpa, fsm, firenoc, echallan, sw and ws

### DIFF
--- a/config-as-code/helm/charts/municipal-services/bpa-calculator/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/bpa-calculator/values.yaml
@@ -44,11 +44,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_MDMS_SEARCH_ENDPOINT
     value: /egov-mdms-service/v1/_search
   - name: EGOV_BILLINGSERVICE_HOST

--- a/config-as-code/helm/charts/municipal-services/bpa-services/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/bpa-services/values.yaml
@@ -43,11 +43,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_USER_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/echallan-calculator/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/echallan-calculator/values.yaml
@@ -42,11 +42,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_MDMS_SEARCH_ENDPOINT
     value: /egov-mdms-service/v1/_search
   - name: EGOV_BILLINGSERVICE_HOST

--- a/config-as-code/helm/charts/municipal-services/echallan-services/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/echallan-services/values.yaml
@@ -43,11 +43,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_USER_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/firenoc-calculator/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/firenoc-calculator/values.yaml
@@ -58,11 +58,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_USER_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/firenoc-services/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/firenoc-services/values.yaml
@@ -61,11 +61,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_USER_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/fsm-calculator/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/fsm-calculator/values.yaml
@@ -50,11 +50,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_BILLINGSERVICE_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/fsm/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/fsm/values.yaml
@@ -44,11 +44,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_URL_SHORTNER_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/sw-calculator/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/sw-calculator/values.yaml
@@ -47,11 +47,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_USER_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/sw-services/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/sw-services/values.yaml
@@ -52,11 +52,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_USER_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/ws-calculator/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/ws-calculator/values.yaml
@@ -47,11 +47,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_USER_HOST
     valueFrom:
       configMapKeyRef:

--- a/config-as-code/helm/charts/municipal-services/ws-services/values.yaml
+++ b/config-as-code/helm/charts/municipal-services/ws-services/values.yaml
@@ -52,11 +52,6 @@ env: |
       configMapKeyRef:
         name: egov-service-host
         key: egov-mdms-service
-  - name: MDMS_V2_HOST
-    valueFrom:
-      configMapKeyRef:
-        name: egov-service-host
-        key: mdms-v2
   - name: EGOV_USER_HOST
     valueFrom:
       configMapKeyRef:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed `MDMS_V2_HOST` environment variable from multiple Helm charts (`bpa-calculator`, `bpa-services`, `echallan-calculator`, `echallan-services`, `firenoc-calculator`, `firenoc-services`, `fsm-calculator`, `fsm`, `sw-calculator`, `sw-services`, `ws-calculator`, and `ws-services`), streamlining configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->